### PR TITLE
docs: expand README and fix truncated -token help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # gitlab-bookmarks
 
+[![Go CI](https://github.com/mikaello/gitlab-bookmarks/actions/workflows/verify-go-build.yml/badge.svg)](https://github.com/mikaello/gitlab-bookmarks/actions/workflows/verify-go-build.yml)
+[![Latest release](https://img.shields.io/github/v/release/mikaello/gitlab-bookmarks)](https://github.com/mikaello/gitlab-bookmarks/releases/latest)
+[![License](https://img.shields.io/github/license/mikaello/gitlab-bookmarks)](LICENSE)
+
 Tool to fetch projects from GitLab to provision your bookmarks.
 
 Run this tool with the GitLab instance of your choice, it will use the API and
-gather all projects into a file called `bookmarks.html`. This file follows the
-bookmarks format expected by browsers for importing. So open your favourite
-browser and import the generated `bookmarks.html` file, you can now use the
-adress bar to search for projects of the chosen GitLab instance.
+gather all projects into a file called `bookmarks.html`.
+This file follows the bookmarks format expected by browsers for importing.
+So open your favourite browser and import the generated `bookmarks.html` file, you can now use the address bar to search for projects of the chosen GitLab instance.
 
-## Usage:
+## Requirements
+
+Go 1.25 or newer (only required for building from source).
+
+## Usage
 
 ```
 $ ./gitlab-bookmarks --help
@@ -22,20 +29,33 @@ Usage of ./gitlab-bookmarks:
   -maxpages int
         the maximum number of pages to fetch, GitLab API is paginated (default 5, 100 per page)
   -token string
-        a token with API read permissions, not required, but only public repos without
+        a token with API read permissions; without it only public repositories will be fetched
 ```
 
 Example usage:
 
-```
+```shell
 ./gitlab-bookmarks -baseurl https://mycompany.gitlab.com -group some-group -group another-group -maxpages 100
 ```
+
+### Creating a token
+
+To access private projects you need a [personal access token](https://docs.gitlab.com/user/profile/personal_access_tokens/) with the `read_api` scope.
+Group access tokens or project access tokens with the same scope also work.
+
+### Importing the generated file
+
+After running the tool you will have a `bookmarks.html` in the current directory.
+
+- **Firefox**: `Bookmarks → Manage bookmarks → Import and Backup → Import bookmarks from HTML…`
+- **Chrome / Edge**: `Bookmark manager → ⋮ → Import bookmarks`
+- **Safari**: `File → Import From → Bookmarks HTML File…`
 
 ## Install
 
 Either download a prebuilt binary from
 [the release page](https://github.com/mikaello/gitlab-bookmarks/releases) (if it
-exist for your system), or build with go:
+exists for your system), or build with go:
 
 ```shell
 go build -o gitlab-bookmarks cmd/provision/main.go

--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -30,7 +30,7 @@ func (i *groupFlags) Set(group string) error {
 }
 
 func init() {
-	token = flag.String("token", "", "a token with API read permissions, not required, but only public repos without")
+	token = flag.String("token", "", "a token with API read permissions; without it only public repositories will be fetched")
 	baseurl = flag.String("baseurl", "https://gitlab.com", "the base url of your GitLab instance, including protocol scheme")
 	maxPages = flag.Int("maxpages", 5, "the maximum number of pages to fetch, GitLab API is paginated")
 	includeForks = flag.Bool("includeforks", false, "if forks should be included (default is false)")


### PR DESCRIPTION
## Summary
- Add CI / latest-release / license badges to the README.
- Add a **Requirements** section, **Creating a token** subsection, and browser-specific **Importing the generated file** steps (Firefox, Chrome/Edge, Safari).
- Fix the `-token` flag help text that was cut off mid-sentence (\"...only public repos without\") so the CLI output and README agree.

## Test plan
- [x] \`go build ./...\` succeeds
- [ ] Render the README on GitHub and confirm badges resolve and links work
- [ ] Run \`./gitlab-bookmarks --help\` and confirm the \`-token\` line reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)