### PR TITLE
refactor: surface errors and drop dead module replace directives

### DIFF
--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -81,7 +81,7 @@ func main() {
 	}
 
 	// create a GitLab client
-	client, err := git.Client(baseurl, *token)
+	client, err := git.Client(*baseurl, *token)
 	if err != nil {
 		log.Fatalf("Error creating GitLab client: %s", err)
 	}
@@ -100,6 +100,11 @@ func main() {
 
 	log.Printf("Total: Found %d repositories", len(repos))
 
-	htmlContent := bookmarks.CreateBookmarkHTML(repos)
-	bookmarks.WriteBookmarkFile(*output, htmlContent)
+	htmlContent, err := bookmarks.CreateBookmarkHTML(repos)
+	if err != nil {
+		log.Fatalf("Error creating bookmark HTML: %s", err)
+	}
+	if err := bookmarks.WriteBookmarkFile(*output, htmlContent); err != nil {
+		log.Fatalf("Error writing bookmark file: %s", err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,3 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 )
-
-replace github.io/gitlab-bookmarks/internal/git => ./internal/git
-
-replace github.io/gitlab-bookmarks/internal/bookmarks => ./internal/bookmarks

--- a/internal/bookmarks/bookmarks.go
+++ b/internal/bookmarks/bookmarks.go
@@ -1,11 +1,10 @@
 package bookmarks
 
 import (
-	"bufio"
 	"bytes"
 	"embed"
+	"fmt"
 	"html/template"
-	"log"
 	"os"
 
 	"gitlab.com/gitlab-org/api/client-go/v2"
@@ -18,23 +17,21 @@ var bookmarksTmpl embed.FS
 // and https://pkg.go.dev/html/template
 
 // CreateBookmarkHTML creates a bookmark content for the given repositories.
-func CreateBookmarkHTML(projects []*gitlab.Project) string {
+func CreateBookmarkHTML(projects []*gitlab.Project) (string, error) {
 	templates := template.Must(template.New("").ParseFS(bookmarksTmpl, "bookmarks.tmpl"))
 
 	var processed bytes.Buffer
-	err := templates.ExecuteTemplate(&processed, "bookmarks", projects)
-
-	if err != nil {
-		log.Fatalf("Could not execute bookmarks template: %s", err)
+	if err := templates.ExecuteTemplate(&processed, "bookmarks", projects); err != nil {
+		return "", fmt.Errorf("execute bookmarks template: %w", err)
 	}
 
-	return processed.String()
+	return processed.String(), nil
 }
 
-// WriteBookmarkFile simply writes 'filename' to disk with content 'htmlContent'
-func WriteBookmarkFile(filename string, htmlContent string) {
-	f, _ := os.Create(filename)
-	w := bufio.NewWriter(f)
-	w.WriteString(htmlContent)
-	w.Flush()
+// WriteBookmarkFile writes 'filename' to disk with content 'htmlContent'.
+func WriteBookmarkFile(filename string, htmlContent string) error {
+	if err := os.WriteFile(filename, []byte(htmlContent), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", filename, err)
+	}
+	return nil
 }

--- a/internal/bookmarks/bookmarks_test.go
+++ b/internal/bookmarks/bookmarks_test.go
@@ -1,0 +1,51 @@
+package bookmarks
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func TestCreateBookmarkHTML(t *testing.T) {
+	activity := time.Unix(1700000000, 0)
+	projects := []*gitlab.Project{
+		{
+			Name:           "alpha",
+			WebURL:         "https://gitlab.example.com/group/alpha",
+			LastActivityAt: &activity,
+		},
+		{
+			Name:           "beta",
+			WebURL:         "https://gitlab.example.com/group/beta",
+			LastActivityAt: &activity,
+		},
+	}
+
+	html, err := CreateBookmarkHTML(projects)
+	if err != nil {
+		t.Fatalf("CreateBookmarkHTML returned error: %s", err)
+	}
+
+	for _, want := range []string{
+		"<!DOCTYPE NETSCAPE-Bookmark-file-1>",
+		"https://gitlab.example.com/group/alpha",
+		">alpha</A>",
+		"https://gitlab.example.com/group/beta",
+		">beta</A>",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, html)
+		}
+	}
+}
+
+func TestWriteBookmarkFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bookmarks.html")
+	if err := WriteBookmarkFile(path, "hello"); err != nil {
+		t.Fatalf("WriteBookmarkFile returned error: %s", err)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,10 +7,8 @@ import (
 )
 
 // Client creates a GitLab client for the given base URL and token.
-func Client(baseurl *string, token string) (*gitlab.Client, error) {
-	url := *baseurl
-	c, err := gitlab.NewClient(token, gitlab.WithBaseURL(url+"/api/v4"))
-	return c, err
+func Client(baseurl string, token string) (*gitlab.Client, error) {
+	return gitlab.NewClient(token, gitlab.WithBaseURL(baseurl+"/api/v4"))
 }
 
 // WhoAmI returns the user that is logged in to GitLab.


### PR DESCRIPTION
## Summary
- \`WriteBookmarkFile\` discarded the \`os.Create\` error and then dereferenced a possibly-nil \`*os.File\`, panicking on any IO/permission failure. Replaced with \`os.WriteFile\` and a returned error.
- \`CreateBookmarkHTML\` called \`log.Fatalf\` on template failure; it now returns an error so callers decide what to do.
- Normalised \`git.Client\` to take \`baseurl string\` instead of \`*string\` (the pointer added no value).
- Removed self-referential \`replace\` directives in \`go.mod\` for \`internal/git\` and \`internal/bookmarks\` — \`replace\` only affects external modules, so these were no-ops.
- Added a small unit test exercising \`CreateBookmarkHTML\` and \`WriteBookmarkFile\` (previously zero test coverage).

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\`
- [ ] Smoke run: \`go run cmd/provision/main.go -baseurl https://gitlab.com -maxpages 1\` and confirm \`bookmarks.html\` is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)