### PR TITLE
ci: enable tests, lint formatting, drop deprecated golint, add CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "37 5 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (Go)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"

--- a/.github/workflows/verify-go-build.yml
+++ b/.github/workflows/verify-go-build.yml
@@ -1,6 +1,9 @@
 name: Go CI
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:
@@ -18,6 +21,15 @@ jobs:
     - name: Verify dependencies
       run: go mod verify
 
+    - name: Check formatting
+      run: |
+        unformatted=$(gofmt -l .)
+        if [ -n "$unformatted" ]; then
+          echo "The following files are not gofmt-clean:"
+          echo "$unformatted"
+          exit 1
+        fi
+
     - name: Build
       run: go build -v ./...
 
@@ -29,11 +41,5 @@ jobs:
         # renovate: datasource=go depName=honnef.co/go/tools/cmd/staticcheck
         version: "v0.7.0"
 
-    - name: Install golint
-      run: go install golang.org/x/lint/golint@latest
-
-    - name: Run golint
-      run: golint ./...
-
-    #- name: Run tests
-    #  run: go test -race -vet=off ./...
+    - name: Run tests
+      run: go test -race -vet=off ./...


### PR DESCRIPTION
## Summary
- Run \`go test -race\` (the step was commented out).
- Trigger on \`pull_request\` so checks appear on PRs, not only after merge. Push trigger limited to \`main\` to avoid double runs.
- Add a \`gofmt\` cleanliness check.
- Drop the \`golang.org/x/lint/golint\` step. \`golint\` is archived (frozen by Google in 2020) and staticcheck already covers its rules.
- Add a CodeQL workflow for baseline SAST coverage (push to main, PRs, and a weekly schedule).

## Test plan
- [ ] CI runs on this PR (\`Go CI\` and \`CodeQL / Analyze (Go)\`)
- [ ] Test step executes (not just builds)
- [ ] Try pushing a deliberately gofmt-dirty file in a scratch branch to confirm the format check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)