### PR TITLE
feat: add -output and -version flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Usage of ./gitlab-bookmarks:
         if forks should be included (default is false)
   -maxpages int
         the maximum number of pages to fetch, GitLab API is paginated (default 5, 100 per page)
+  -output string
+        path to the bookmarks file to write (default "bookmarks.html")
   -token string
         a token with API read permissions; without it only public repositories will be fetched
+  -version
+        print version information and exit
 ```
 
 Example usage:

--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/url"
+	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.io/gitlab-bookmarks/internal/bookmarks"
@@ -13,8 +16,10 @@ import (
 var (
 	token        *string
 	baseurl      *string
+	output       *string
 	maxPages     *int
 	includeForks *bool
+	showVersion  *bool
 	groups       groupFlags
 )
 
@@ -32,13 +37,43 @@ func (i *groupFlags) Set(group string) error {
 func init() {
 	token = flag.String("token", "", "a token with API read permissions; without it only public repositories will be fetched")
 	baseurl = flag.String("baseurl", "https://gitlab.com", "the base url of your GitLab instance, including protocol scheme")
+	output = flag.String("output", "bookmarks.html", "path to the bookmarks file to write")
 	maxPages = flag.Int("maxpages", 5, "the maximum number of pages to fetch, GitLab API is paginated")
 	includeForks = flag.Bool("includeforks", false, "if forks should be included (default is false)")
+	showVersion = flag.Bool("version", false, "print version information and exit")
 	flag.Var(&groups, "group", "group to search for projects (use multiple flags for more groups), if not set all groups will be searched")
+}
+
+// version is overridden via -ldflags="-X main.version=..." at release build
+// time. When unset, fall back to the VCS information embedded by `go build`.
+var version = ""
+
+func versionString() string {
+	if version != "" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" && s.Value != "" {
+			return s.Value
+		}
+	}
+	return "unknown"
 }
 
 func main() {
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(versionString())
+		os.Exit(0)
+	}
 
 	_, err := url.ParseRequestURI(*baseurl)
 	if err != nil {
@@ -66,5 +101,5 @@ func main() {
 	log.Printf("Total: Found %d repositories", len(repos))
 
 	htmlContent := bookmarks.CreateBookmarkHTML(repos)
-	bookmarks.WriteBookmarkFile("bookmarks.html", htmlContent)
+	bookmarks.WriteBookmarkFile(*output, htmlContent)
 }

--- a/internal/bookmarks/bookmarks.go
+++ b/internal/bookmarks/bookmarks.go
@@ -33,8 +33,7 @@ func CreateBookmarkHTML(projects []*gitlab.Project) string {
 
 // WriteBookmarkFile simply writes 'filename' to disk with content 'htmlContent'
 func WriteBookmarkFile(filename string, htmlContent string) {
-	outputPath := "./" + filename
-	f, _ := os.Create(outputPath)
+	f, _ := os.Create(filename)
 	w := bufio.NewWriter(f)
 	w.WriteString(htmlContent)
 	w.Flush()


### PR DESCRIPTION
## Summary
- \`-output\` lets the caller choose where the bookmarks HTML is written. Default is \`bookmarks.html\` so existing usage is unchanged.
- The hardcoded \`./\` prefix inside \`WriteBookmarkFile\` is removed so absolute and relative paths both work.
- \`-version\` prints the build version and exits. The value prefers an \`-ldflags=\"-X main.version=...\"\` injected string for release binaries, and otherwise falls back to the VCS revision embedded by \`go build\`.
- README usage block updated to list both flags.

## Test plan
- [x] \`go build ./...\`
- [x] \`gitlab-bookmarks -version\` prints a version string (verified: \`v0.0.0-...+dirty\` from VCS info)
- [x] \`gitlab-bookmarks --help\` shows \`-output\` and \`-version\`
- [ ] \`gitlab-bookmarks -baseurl https://gitlab.com -maxpages 1 -output /tmp/x.html\` writes the file at the absolute path

## Follow-up (not in this PR)
To stamp release binaries with a real semver, the \`release.yml\` workflow could pass \`-ldflags=\"-X main.version=\${{ github.ref_name }}\"\` to the build action. Happy to send that as a separate PR if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)