### PR TITLE
ci: stamp release binaries with the git tag via -ldflags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,4 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           project_path: cmd/provision/
+          ldflags: -s -w -X main.version=${{ github.ref_name }}


### PR DESCRIPTION
## Summary
Pass \`-X main.version=\${{ github.ref_name }}\` to the release build so the binary's \`-version\` output reports the tag (e.g. \`v0.5.0\`) instead of falling back to the embedded VCS revision.

Also pass \`-s -w\` to strip the symbol table and DWARF debug info, which meaningfully shrinks the published artifacts.

## Notes on ordering with #154
\`main.version\` is introduced in #154. If this PR lands first, \`-X\` against an unknown symbol is silently ignored by the Go linker — so merging in either order is safe. After both land and a new tag is cut, \`./gitlab-bookmarks -version\` will print the tag.

## Test plan
- [ ] Cut a pre-release tag after merging both this and #154 and confirm \`./gitlab-bookmarks -version\` prints the tag
- [ ] Confirm the release artifact size drops slightly (from \`-s -w\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)